### PR TITLE
Switch to RemoteCANCoder from FUSEDCANCoder (to remove unlicensed feature in use)

### DIFF
--- a/Cresendo/src/main/java/frc/robot/generated/TunerConstants.java
+++ b/Cresendo/src/main/java/frc/robot/generated/TunerConstants.java
@@ -82,7 +82,7 @@ public class TunerConstants {
             .withDriveInertia(kDriveInertia)
             .withSteerFrictionVoltage(kSteerFrictionVoltage)
             .withDriveFrictionVoltage(kDriveFrictionVoltage)
-            .withFeedbackSource(SteerFeedbackType.FusedCANcoder)
+            .withFeedbackSource(SteerFeedbackType.RemoteCANcoder)
             .withCouplingGearRatio(kCoupleRatio)
             .withSteerMotorInverted(kSteerMotorReversed);
 


### PR DESCRIPTION
This should fix the status lights on the swerve TalonFX. Documentation on this specific defaulting behavior here: [Phoenix 6 docs](https://v6.docs.ctr-electronics.com/en/stable/docs/api-reference/device-specific/talonfx/remote-sensors.html)